### PR TITLE
README: Add arm64 trees

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,8 @@
 [![Build Status lto-cfi](https://github.com/clangbuiltlinux/continuous-integration2/workflows/lto-cfi/badge.svg)](https://github.com/clangbuiltlinux/continuous-integration2/actions?query=workflow%3Alto-cfi)
 [![Build Status lto-cfi-tip](https://github.com/clangbuiltlinux/continuous-integration2/workflows/lto-cfi-tip/badge.svg)](https://github.com/clangbuiltlinux/continuous-integration2/actions?query=workflow%3Alto-cfi-tip)
 [![Build Status tip](https://github.com/clangbuiltlinux/continuous-integration2/workflows/tip/badge.svg)](https://github.com/clangbuiltlinux/continuous-integration2/actions?query=workflow%3Atip)
+[![Build Status arm64](https://github.com/clangbuiltlinux/continuous-integration2/workflows/arm64/badge.svg)](https://github.com/clangbuiltlinux/continuous-integration2/actions?query=workflow%3Aarm64)
+[![Build Status arm64-fixes](https://github.com/clangbuiltlinux/continuous-integration2/workflows/arm64-fixes/badge.svg)](https://github.com/clangbuiltlinux/continuous-integration2/actions?query=workflow%3Aarm64-fixes)
 
 - [Official Kernel Docs](https://www.kernel.org/doc/html/latest/kbuild/llvm.html)
 - [Issue tracker](https://github.com/ClangBuiltLinux/linux/issues)


### PR DESCRIPTION
Corresponds to https://github.com/ClangBuiltLinux/continuous-integration2/pull/108.