### PR TITLE
readme.md: Update IRC channel to Libera

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@
 - [Wiki](https://github.com/ClangBuiltLinux/linux/wiki)
 - [Repos](https://github.com/ClangBuiltLinux)
 - Mailing List: `clang-built-linux@googlegroups.com` ([archive](https://groups.google.com/forum/#!forum/clang-built-linux))
-- IRC: `#clangbuiltlinux` on chat.freenode.net ([webchat](http://webchat.freenode.net/?channels=clangbuiltlinux))
+- IRC: `#clangbuiltlinux` on [irc.libera.chat](https://libera.chat/guides/connect) ([web client](https://web.libera.chat/?channel=#clangbuiltlinux))
 - Telegram: [@ClangBuiltLinux](https://t.me/ClangBuiltLinux)
 - Bi-weekly video meeting
   - [Calendar](https://calendar.google.com/calendar/embed?src=google.com_bbf8m6m4n8nq5p2bfjpele0n5s%40group.calendar.google.com)


### PR DESCRIPTION
The freenode channel is deprecated. Link to new location at Libera.