### PR TITLE
remove mention of nds32

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -132,7 +132,6 @@ The following architectures are targetable from the Linux kernel but not LLVM:
 * h8300
 * ia64
 * microblaze
-* nds32
 * nios2
 * openrisc
 * parisc


### PR DESCRIPTION
This arch was removed from the kernel in 5.18. See:
https://lore.kernel.org/lkml/CAK8P3a0DeZ4Gx6fOqLkjmA7kNYW5ZHq8BUpWTXXdqdtxcHRNLg@mail.gmail.com/