### PR TITLE
take down link to meetup

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,5 @@
 ## Useful links
 
-We're having our third meetup Sept 10-11 2022 in Dublin, Ireland. Please
-see [our page](https://clangbuiltlinux.github.io/cbl-meetup/) for more info!
-
 [![4.14-clang-13 build status](https://github.com/clangbuiltlinux/continuous-integration2/actions/workflows/4.14-clang-13.yml/badge.svg)](https://github.com/clangbuiltlinux/continuous-integration2/actions/workflows/4.14-clang-13.yml)
 [![4.14-clang-14 build status](https://github.com/clangbuiltlinux/continuous-integration2/actions/workflows/4.14-clang-14.yml/badge.svg)](https://github.com/clangbuiltlinux/continuous-integration2/actions/workflows/4.14-clang-14.yml)
 [![4.14-clang-15 build status](https://github.com/clangbuiltlinux/continuous-integration2/actions/workflows/4.14-clang-15.yml/badge.svg)](https://github.com/clangbuiltlinux/continuous-integration2/actions/workflows/4.14-clang-15.yml)


### PR DESCRIPTION
Preserved on
https://github.com/ClangBuiltLinux/linux/wiki/Talks,-Presentations,-and-Communications via
https://github.com/ClangBuiltLinux/linux/wiki/Talks,-Presentations,-and-Communications/_compare/0c020f115e17894a8c221acec3fdcd2cc3fd9ec3...dd55432a4b2bc63e1ebc84932eb13f9e5d26e1b0