### PR TITLE
CSS: Make the site wider

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,21 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+.wrapper {
+	width: 98%;
+}
+
+header {
+	width: 20%;
+}
+
+section {
+	width: 80%;
+}
+
+footer {
+	display: none;
+	visibility: hidden;
+}


### PR DESCRIPTION
The current theme uses fixed-width pixel sizes for the body. This makes things needlessly narrow, especially if we want to put a table of build status icons.

Signed-off-by: Kees Cook <keescook@chromium.org>