### PR TITLE
Improve readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,9 @@
 - Discord: `#clang-built-linux` in the [LLVM server](https://discord.gg/xS7Z362)
 - Bi-weekly video meeting
   - [Calendar](https://calendar.google.com/calendar/embed?src=google.com_bbf8m6m4n8nq5p2bfjpele0n5s%40group.calendar.google.com)
-  - [Hangouts Meet](https://meet.google.com/yjf-jyqk-iaz)
+  - [Google Meet](https://meet.google.com/yjf-jyqk-iaz)
+
+## Architecture Support
 
 The following architectures are targetable from both LLVM and the Linux kernel
 and are relatively well supported and tested:


### PR DESCRIPTION
Let's improve the readme (and thus the website) by altering a few things:

1) Change Hangouts to Google Meet as [Hangouts is now dead ☠](https://arstechnica.com/gadgets/2022/06/google-hangouts-finally-gets-a-shutdown-date-november-2022/)

2) Add an **Architecture Support** heading to separate it from the **Useful Links** section.

You can *visually* check out the changes on my fork: https://github.com/JustinStitt/ClangBuiltLinux.github.io/tree/readme-cleanup

More or less an ancestor of https://github.com/ClangBuiltLinux/ClangBuiltLinux.github.io/pull/58 stemming from Nick's comment.