### PR TITLE
readme: 2023 is over

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ## Meetups
-- Nov 11, 2023 - [4th Annual ClangBuiltLinux Meetup](/meetup.md) - Richmond, VA
-- Nov 13-15, 2023 - [Toolchains Track](https://lpc.events/event/17/sessions/156/) @ [Linux Plumbers Conf 2023](https://lpc.events/event/17/) - Richmond, VA
+- No scheduled CBL meetups yet for 2024!
+- Check out the regular <a href="https://www.meetup.com/llvm-bay-area-social/">Bay Area LLVM Meetups</a> instead
 
 ## Build status
 


### PR DESCRIPTION
Drop the old Meetup information and link to at least the Bay Area LLVM meetups.